### PR TITLE
feat: output full content for rss feed

### DIFF
--- a/docaid/src/utils/generateRSS.ts
+++ b/docaid/src/utils/generateRSS.ts
@@ -34,7 +34,6 @@ export function generateRSS(opts: {
       ...item,
       id: item.id || item.link,
       description: item.description || item.title,
-      content: item.html,
     };
     if (!item.author && !item.authors && opts.feedOpts.author) {
       newItem.author = opts.feedOpts.author;

--- a/docaid/src/utils/generateRSS.ts
+++ b/docaid/src/utils/generateRSS.ts
@@ -34,6 +34,7 @@ export function generateRSS(opts: {
       ...item,
       id: item.id || item.link,
       description: item.description || item.title,
+      content: item.html,
     };
     if (!item.author && !item.authors && opts.feedOpts.author) {
       newItem.author = opts.feedOpts.author;

--- a/umi-plugin-docaid/src/buildDocs.ts
+++ b/umi-plugin-docaid/src/buildDocs.ts
@@ -114,9 +114,7 @@ export async function buildDoc(root: string, dir: string, opts: IOpts) {
         const ret = {
           title: doc.title,
           link: `${opts.config.siteUrl}${dir}/${doc.file.replace(/\.md$/, '')}`,
-          // TODO: support full content by default
-          content: '',
-          html: doc.html,
+          content: doc.html,
           date: new Date(doc.publishedAt),
         };
         return rssOpts.transform ? rssOpts.transform(ret, { doc }) : ret;

--- a/umi-plugin-docaid/src/buildDocs.ts
+++ b/umi-plugin-docaid/src/buildDocs.ts
@@ -116,6 +116,7 @@ export async function buildDoc(root: string, dir: string, opts: IOpts) {
           link: `${opts.config.siteUrl}${dir}/${doc.file.replace(/\.md$/, '')}`,
           // TODO: support full content by default
           content: '',
+          html: doc.html,
           date: new Date(doc.publishedAt),
         };
         return rssOpts.transform ? rssOpts.transform(ret, { doc }) : ret;


### PR DESCRIPTION
I have tested on `examples/theme-leerob` of this repo and anything works well.

The post at `examples/theme-leerob/docs/posts/hello-world.md`:
```md
---
title: "Hello World"
titleImage: "https://img.alicdn.com/imgextra/i2/O1CN01Q93IFG1zkvJLH40c6_!!6000000006753-2-tps-2560-1440.png"
titleImageCaption: "介绍"
publishedAt: "2023/09/24"
---

Happy to see you here! This is a demo post.

```

RSS feed:
```xml
<?xml version="1.0" encoding="utf-8"?>
<feed xmlns="http://www.w3.org/2005/Atom">
    <id>https://your-site.com/</id>
    <title>Docaid</title>
    <updated>2023-02-13T06:53:29.591Z</updated>
    <generator>https://github.com/jpmonette/feed</generator>
    <author>
        <name>Your Name</name>
        <email>your-email@gmail.com</email>
        <uri>https://your-site.com/</uri>
    </author>
    <link rel="alternate" href="https://your-site.com/"/>
    <link rel="self" href="https://your-site.com/rss.xml"/>
    <subtitle>Docaid</subtitle>
    <logo>https://img.alicdn.com/imgextra/i1/O1CN01FwDVoc1YGhgE28l5B_!!6000000003032-2-tps-200-200.png</logo>
    <icon>https://img.alicdn.com/imgextra/i1/O1CN01FwDVoc1YGhgE28l5B_!!6000000003032-2-tps-200-200.png</icon>
    <rights>Docaid</rights>
    <entry>
        <title type="html"><![CDATA[Hello World]]></title>
        <id>https://your-site.com/posts/hello-world</id>
        <link href="https://your-site.com/posts/hello-world"/>
        <updated>2023-09-23T16:00:00.000Z</updated>
        <summary type="html"><![CDATA[Hello World]]></summary>
        <content type="html"><![CDATA[<p>Happy to see you here! This is a demo post.</p>
]]></content>
    </entry>
</feed>
```

Reeder 5 mac app:
![CleanShot 2023-02-13 at 14 55 34](https://user-images.githubusercontent.com/21964227/218392223-2dd1a256-b5a3-44e6-89dd-5779fc36a49b.png)
